### PR TITLE
Añadiendo browserSync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,8 @@ gulp.task('compress', function (cb) {
     pump([
         gulp.src('app/js/*.js'),
         uglify(),
-        gulp.dest('app/js/dist')
+        gulp.dest('app/js/dist'),
+        browserSync.stream()
     ],
     cb
   );


### PR DESCRIPTION
Añadimos una función para disparar el browserSync después del cambio y compilación en los archivos *.js .