### PR TITLE
Nueva versión para gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,10 @@ var browserSync = require('browser-sync').create();
 gulp.task('serve', ['html', 'css', 'javascript'], function() {
 
     browserSync.init({
-        server: "./app"
+        startPath : "./app" ,
+        server:{
+            baseDir: './'
+        }
     });
 
     gulp.watch("app/js/*.js", ['javascript']).on('change', browserSync.reload);


### PR DESCRIPTION
Con esta versión no tendrás problemas a la hora de inyectar directorios por debajo de la raíz /app como por ejemplo /bower_components , ya que el servidor baseDir debe ser el punto más alto de su árbol y por ejemplo con Frameworks descargados con bower te dará problemas.

NOTA: El funcionamiento del plugin sigue siendo exactamente el mismo, la única característica que se le añade es que ahora puede inyectar sin problemas cualquier directorio por debajo de la raíz /app y con ello se corrige un pequeño "Bug". 